### PR TITLE
 Fixes #7. Updated illuminate/support requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.x"
+        "illuminate/support": ">=4.1 <6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*",


### PR DESCRIPTION
This fixes and allows for future versions of laravel 5.
By semantic versioning there shouldn't be any backward incompatible changes in illuminate support until ver 6.0
